### PR TITLE
Add Flask-based finance calculator website

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,108 @@
+from flask import Flask, render_template, request
+
+from calculators.capital_gains import breakeven_return, CapitalGainsError
+from calculators.dca_optimizer import calculate_optimal_dca, DCAError
+from calculators.options_strategy import expected_move, sell_vs_exercise, OptionsError
+from calculators.compound_interest import (
+    future_value,
+    years_to_goal,
+    required_rate,
+    required_deposit,
+    plot_history,
+)
+
+app = Flask(__name__)
+
+
+@app.route("/")
+def index():
+    return render_template("index.html")
+
+
+@app.route("/capital-gains", methods=["GET", "POST"])
+def capital_gains_view():
+    result = None
+    if request.method == "POST":
+        try:
+            cv = float(request.form["current_value"])
+            cb = float(request.form["cost_basis"])
+            tr = float(request.form["tax_rate"])
+            res = breakeven_return(cv, cb, tr)
+            result = res.__dict__
+        except (ValueError, CapitalGainsError) as e:
+            result = {"error": str(e)}
+    return render_template("capital_gains.html", result=result)
+
+
+@app.route("/dca", methods=["GET", "POST"])
+def dca_view():
+    result = None
+    if request.method == "POST":
+        try:
+            capital = float(request.form["capital"])
+            price = float(request.form["price"])
+            fee = float(request.form["fee"])
+            vol = float(request.form["volatility"])
+            res = calculate_optimal_dca(capital, price, fee, vol)
+            result = res.__dict__
+        except (ValueError, DCAError) as e:
+            result = {"error": str(e)}
+    return render_template("dca.html", result=result)
+
+
+@app.route("/options", methods=["GET", "POST"])
+def options_view():
+    result = None
+    if request.method == "POST":
+        calc_type = request.form.get("calc_type")
+        try:
+            if calc_type == "move":
+                stock = float(request.form.get("stock_price", 0))
+                call = float(request.form.get("call_price", 0))
+                put = float(request.form.get("put_price", 0))
+                res = expected_move(stock, call, put)
+                result = {**res.__dict__, "type": "move"}
+            else:
+                stock = float(request.form.get("stock_price_sell", 0))
+                strike = float(request.form.get("strike_price", 0))
+                premium = float(request.form.get("option_premium", 0))
+                res = sell_vs_exercise(stock, strike, premium)
+                result = {**res.__dict__, "type": "sell"}
+        except (ValueError, OptionsError) as e:
+            result = {"error": str(e)}
+    return render_template("options.html", result=result)
+
+
+@app.route("/compound", methods=["GET", "POST"])
+def compound_view():
+    result = None
+    if request.method == "POST":
+        calc_type = request.form.get("calc_type")
+        try:
+            principal = float(request.form.get("principal", 0) or 0)
+            deposit = float(request.form.get("deposit", 0) or 0)
+            freq = int(request.form.get("frequency", 1) or 1)
+            begin = bool(request.form.get("begin"))
+            rate = float(request.form.get("rate", 0) or 0)
+            years = float(request.form.get("years", 0) or 0)
+            goal = float(request.form.get("goal", 0) or 0)
+            if calc_type == "balance":
+                balance, history = future_value(principal, rate, int(years), freq, deposit, begin)
+                image = plot_history(history) if history else None
+                result = {"type": "balance", "balance": balance, "image": image}
+            elif calc_type == "time":
+                y, _ = years_to_goal(principal, rate, freq, deposit, begin, goal)
+                result = {"type": "time", "years": y}
+            elif calc_type == "rate":
+                r = required_rate(principal, int(years), freq, deposit, begin, goal)
+                result = {"type": "rate", "rate": r}
+            elif calc_type == "deposit":
+                d = required_deposit(principal, rate, int(years), freq, begin, goal)
+                result = {"type": "deposit", "deposit": d}
+        except ValueError as e:
+            result = {"error": str(e)}
+    return render_template("compound.html", result=result)
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/calculators/capital_gains.py
+++ b/calculators/capital_gains.py
@@ -1,0 +1,46 @@
+"""Utility functions for the Capital Gains Opportunity Cost Calculator."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class CapitalGainsResult:
+    capital_gain: float
+    tax_cost: float
+    post_tax_proceeds: float
+    required_return: float
+
+
+class CapitalGainsError(ValueError):
+    """Raised when inputs are invalid for the capital gains calculation."""
+
+
+def breakeven_return(current_value: float, cost_basis: float, tax_rate: float) -> CapitalGainsResult:
+    """Calculate the breakeven return after paying capital gains tax.
+
+    Args:
+        current_value: Current market value of the investment.
+        cost_basis: Original purchase price of the investment.
+        tax_rate: Capital gains tax rate expressed as a decimal.
+
+    Returns:
+        CapitalGainsResult containing intermediate values and the required return.
+
+    Raises:
+        CapitalGainsError: If any of the inputs are invalid or the calculation cannot be performed.
+    """
+    if current_value <= 0 or cost_basis <= 0 or not (0 <= tax_rate < 1):
+        raise CapitalGainsError("Values must be positive and tax rate between 0 and 1.")
+
+    if current_value < cost_basis:
+        raise CapitalGainsError("Current value is below cost basis; this results in a capital loss.")
+
+    capital_gain = current_value - cost_basis
+    tax_cost = tax_rate * capital_gain
+    post_tax_proceeds = current_value - tax_cost
+
+    if post_tax_proceeds <= 0:
+        raise CapitalGainsError("Post-tax proceeds are zero or negative; cannot compute return.")
+
+    required_return = tax_cost / post_tax_proceeds
+    return CapitalGainsResult(capital_gain, tax_cost, post_tax_proceeds, required_return)

--- a/calculators/compound_interest.py
+++ b/calculators/compound_interest.py
@@ -1,0 +1,127 @@
+"""Compound interest calculation utilities."""
+
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass
+from io import BytesIO
+from typing import List
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+@dataclass
+class HistoryEntry:
+    year: int
+    balance: float
+    principal: float
+    total_deposits: float
+    interest_earned: float
+
+
+def future_value(principal: float, annual_rate: float, years: int, periods_per_year: int,
+                 periodic_deposit: float, deposit_at_beginning: bool) -> tuple[float, List[HistoryEntry]]:
+    """Calculate final balance and yearly history for an investment."""
+    rate_per_period = (annual_rate / 100) / periods_per_year
+    history: List[HistoryEntry] = []
+
+    for year in range(years + 1):
+        num_periods = year * periods_per_year
+        fv_principal = principal * ((1 + rate_per_period) ** num_periods)
+        if rate_per_period:
+            fv_deposits = periodic_deposit * (((1 + rate_per_period) ** num_periods - 1) / rate_per_period)
+            if deposit_at_beginning:
+                fv_deposits *= (1 + rate_per_period)
+        else:
+            fv_deposits = periodic_deposit * num_periods
+        balance = fv_principal + fv_deposits
+        total_deposits = periodic_deposit * num_periods
+        interest = balance - principal - total_deposits
+        history.append(HistoryEntry(year, balance, principal, total_deposits, interest))
+    final_balance = history[-1].balance
+    return final_balance, history
+
+
+def years_to_goal(principal: float, annual_rate: float, periods_per_year: int,
+                  periodic_deposit: float, deposit_at_beginning: bool, goal: float,
+                  max_years: int = 1000) -> tuple[int, List[HistoryEntry]]:
+    """Return number of years required to reach a savings goal."""
+    year = 0
+    history: List[HistoryEntry] = []
+    while year <= max_years:
+        balance, hist = future_value(principal, annual_rate, year, periods_per_year,
+                                     periodic_deposit, deposit_at_beginning)
+        history = hist
+        if balance >= goal:
+            return year, history
+        year += 1
+    raise ValueError("Goal not reached within max_years")
+
+
+def required_rate(principal: float, years: int, periods_per_year: int,
+                  periodic_deposit: float, deposit_at_beginning: bool, goal: float,
+                  tolerance: float = 0.0001) -> float:
+    """Return annual rate needed to reach goal in given time."""
+    low, high = 0.0, 100.0
+    rate_val = None
+    for _ in range(100):
+        mid = (low + high) / 2
+        balance, _ = future_value(principal, mid, years, periods_per_year,
+                                  periodic_deposit, deposit_at_beginning)
+        if abs(balance - goal) < tolerance:
+            rate_val = mid
+            break
+        if balance < goal:
+            low = mid
+        else:
+            high = mid
+    if rate_val is None:
+        rate_val = (low + high) / 2
+    return rate_val
+
+
+def required_deposit(principal: float, annual_rate: float, years: int, periods_per_year: int,
+                     deposit_at_beginning: bool, goal: float) -> float:
+    """Return periodic deposit required to reach a goal."""
+    rate_per_period = (annual_rate / 100) / periods_per_year
+    num_periods = years * periods_per_year
+    fv_principal = principal * ((1 + rate_per_period) ** num_periods)
+    required_fv = goal - fv_principal
+    if required_fv <= 0:
+        return 0.0
+    if rate_per_period:
+        denominator = (((1 + rate_per_period) ** num_periods - 1) / rate_per_period)
+        if deposit_at_beginning:
+            denominator *= (1 + rate_per_period)
+        if denominator == 0:
+            return 0.0
+        return required_fv / denominator
+    return required_fv / num_periods
+
+
+def plot_history(history: List[HistoryEntry]) -> str:
+    """Return a base64-encoded PNG of the investment growth history."""
+    years = [h.year for h in history]
+    principal = [h.principal for h in history]
+    deposits = [h.total_deposits for h in history]
+    interest = [h.interest_earned for h in history]
+
+    principal_arr = np.array(principal)
+    deposits_arr = np.array(deposits)
+    interest_arr = np.array(interest)
+
+    plt.style.use('seaborn-v0_8-darkgrid')
+    fig, ax = plt.subplots(figsize=(10, 6))
+    ax.bar(years, principal_arr, label='Initial Balance', color='#003f5c')
+    ax.bar(years, deposits_arr, bottom=principal_arr, label='Total Contributions', color='#7a5195')
+    ax.bar(years, interest_arr, bottom=principal_arr + deposits_arr, label='Interest', color='#ffa600')
+    ax.set_xlabel('Years')
+    ax.set_ylabel('Balance')
+    ax.legend()
+    buf = BytesIO()
+    plt.tight_layout()
+    fig.savefig(buf, format='png')
+    plt.close(fig)
+    buf.seek(0)
+    return base64.b64encode(buf.getvalue()).decode('utf-8')

--- a/calculators/dca_optimizer.py
+++ b/calculators/dca_optimizer.py
@@ -1,0 +1,40 @@
+"""Utility function for the Dollar-Cost Averaging (DCA) strategy optimizer."""
+
+import math
+from dataclasses import dataclass
+
+
+@dataclass
+class DCAResult:
+    optimal_trades: int
+    trigger_percentage: float
+    capital_per_trade: float
+
+
+class DCAError(ValueError):
+    """Raised when the DCA strategy cannot be computed with given inputs."""
+
+
+def calculate_optimal_dca(total_capital: float, share_price: float, commission_fee: float,
+                           annualized_volatility: float) -> DCAResult:
+    """Determine optimal trade count and price trigger for a DCA strategy."""
+    if total_capital <= 0 or share_price <= 0 or commission_fee < 0 or annualized_volatility < 0:
+        raise DCAError("Inputs must be positive numbers (commission can be 0).")
+
+    if commission_fee > 0:
+        n_commission_cap = math.floor((0.05 * total_capital) / commission_fee)
+    else:
+        n_commission_cap = math.floor(total_capital / share_price)
+
+    if (share_price + commission_fee) > 0:
+        n_viability_constraint = math.floor(total_capital / (share_price + commission_fee))
+    else:
+        n_viability_constraint = 0
+
+    n_optimal = min(n_commission_cap, n_viability_constraint)
+    if n_optimal <= 0:
+        raise DCAError("Investment not feasible; capital too low for a single trade.")
+
+    trigger_percentage = (annualized_volatility / math.sqrt(n_optimal)) if n_optimal > 0 else 0
+    capital_per_trade = total_capital / n_optimal
+    return DCAResult(n_optimal, trigger_percentage, capital_per_trade)

--- a/calculators/options_strategy.py
+++ b/calculators/options_strategy.py
@@ -1,0 +1,46 @@
+"""Option strategy helper functions."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class ExpectedMoveResult:
+    expected_move: float
+    expected_percentage: float
+    lower_bound: float
+    upper_bound: float
+
+
+@dataclass
+class SellVsExerciseResult:
+    profit_from_selling: float
+    profit_from_exercising: float
+    extrinsic_value: float
+
+
+class OptionsError(ValueError):
+    """Raised when provided inputs are invalid for option strategy calculations."""
+
+
+def expected_move(stock_price: float, call_price: float, put_price: float) -> ExpectedMoveResult:
+    """Calculate the market's expected move using an ATM straddle."""
+    if stock_price <= 0 or call_price < 0 or put_price < 0:
+        raise OptionsError("Prices must be non-negative and stock price positive.")
+    move = call_price + put_price
+    percentage = move / stock_price
+    lower = stock_price - move
+    upper = stock_price + move
+    return ExpectedMoveResult(move, percentage, lower, upper)
+
+
+def sell_vs_exercise(stock_price: float, strike_price: float, option_premium: float) -> SellVsExerciseResult:
+    """Compare profits from selling versus exercising an option."""
+    if stock_price <= 0 or strike_price <= 0 or option_premium < 0:
+        raise OptionsError("Prices must be positive and premium non-negative.")
+    if stock_price <= strike_price:
+        raise OptionsError("Stock price must exceed strike price for an in-the-money call option.")
+    intrinsic_value = stock_price - strike_price
+    profit_sell = option_premium
+    profit_exercise = intrinsic_value
+    extrinsic = option_premium - intrinsic_value
+    return SellVsExerciseResult(profit_sell, profit_exercise, extrinsic)

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Finance Calculators</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; }
+        nav a { margin-right: 15px; }
+        .error { color: red; }
+    </style>
+</head>
+<body>
+<nav>
+    <a href="/">Home</a>
+    <a href="/capital-gains">Capital Gains</a>
+    <a href="/dca">DCA Optimizer</a>
+    <a href="/options">Options Strategy</a>
+    <a href="/compound">Compound Interest</a>
+</nav>
+<hr>
+{% block content %}{% endblock %}
+</body>
+</html>

--- a/templates/capital_gains.html
+++ b/templates/capital_gains.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Capital Gains Opportunity Cost Calculator</h2>
+<form method="post">
+    <label>Current Investment Value: <input type="number" step="any" name="current_value" required></label><br>
+    <label>Original Cost Basis: <input type="number" step="any" name="cost_basis" required></label><br>
+    <label>Capital Gains Tax Rate (decimal): <input type="number" step="any" name="tax_rate" required></label><br>
+    <button type="submit">Calculate</button>
+</form>
+{% if result %}
+    {% if result.error %}
+        <p class="error">{{ result.error }}</p>
+    {% else %}
+        <p>Capital Gain: {{ result.capital_gain|round(2) }}</p>
+        <p>Tax Cost: {{ result.tax_cost|round(2) }}</p>
+        <p>Post-Tax Proceeds: {{ result.post_tax_proceeds|round(2) }}</p>
+        <p><strong>Required Return: {{ (result.required_return*100)|round(2) }}%</strong></p>
+    {% endif %}
+{% endif %}
+{% endblock %}

--- a/templates/compound.html
+++ b/templates/compound.html
@@ -1,0 +1,36 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Compound Interest Calculator</h2>
+<form method="post">
+    <label>Calculation:
+        <select name="calc_type">
+            <option value="balance">Final Balance</option>
+            <option value="time">Time to Goal</option>
+            <option value="rate">Required Interest Rate</option>
+            <option value="deposit">Required Periodic Deposit</option>
+        </select>
+    </label><br>
+    <label>Initial Balance: <input type="number" step="any" name="principal"></label><br>
+    <label>Periodic Deposit: <input type="number" step="any" name="deposit"></label><br>
+    <label>Deposits per Year: <input type="number" name="frequency" value="12"></label><br>
+    <label>Deposit at Beginning? <input type="checkbox" name="begin"></label><br>
+    <label>Annual Interest Rate (%): <input type="number" step="any" name="rate"></label><br>
+    <label>Years: <input type="number" step="any" name="years"></label><br>
+    <label>Goal Amount: <input type="number" step="any" name="goal"></label><br>
+    <button type="submit">Compute</button>
+</form>
+{% if result %}
+    {% if result.error %}
+        <p class="error">{{ result.error }}</p>
+    {% elif result.type == 'balance' %}
+        <p>Final Balance: {{ result.balance|round(2) }}</p>
+        {% if result.image %}<img src="data:image/png;base64,{{ result.image }}" alt="Growth graph">{% endif %}
+    {% elif result.type == 'time' %}
+        <p>Years Needed: {{ result.years }}</p>
+    {% elif result.type == 'rate' %}
+        <p>Required Interest Rate: {{ result.rate|round(2) }}%</p>
+    {% elif result.type == 'deposit' %}
+        <p>Required Deposit: {{ result.deposit|round(2) }}</p>
+    {% endif %}
+{% endif %}
+{% endblock %}

--- a/templates/dca.html
+++ b/templates/dca.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>DCA Strategy Optimizer</h2>
+<form method="post">
+    <label>Total Capital: <input type="number" step="any" name="capital" required></label><br>
+    <label>Current Share Price: <input type="number" step="any" name="price" required></label><br>
+    <label>Commission Fee: <input type="number" step="any" name="fee" required></label><br>
+    <label>Annualized Volatility (decimal): <input type="number" step="any" name="volatility" required></label><br>
+    <button type="submit">Optimize</button>
+</form>
+{% if result %}
+    {% if result.error %}
+        <p class="error">{{ result.error }}</p>
+    {% else %}
+        <p>Optimal Trades: {{ result.optimal_trades }}</p>
+        <p>Price-Drop Trigger: {{ (result.trigger_percentage*100)|round(2) }}%</p>
+        <p>Capital per Trade: {{ result.capital_per_trade|round(2) }}</p>
+    {% endif %}
+{% endif %}
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Finance Calculators</h1>
+<p>Select a calculator from the navigation menu.</p>
+{% endblock %}

--- a/templates/options.html
+++ b/templates/options.html
@@ -1,0 +1,48 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Options Strategy Calculator</h2>
+<form method="post">
+    <label>Select Calculation:
+        <select name="calc_type">
+            <option value="move">Market Expected Move</option>
+            <option value="sell">Sell vs Exercise</option>
+        </select>
+    </label><br>
+    <div id="move-fields">
+        <label>Stock Price: <input type="number" step="any" name="stock_price"></label><br>
+        <label>ATM Call Price: <input type="number" step="any" name="call_price"></label><br>
+        <label>ATM Put Price: <input type="number" step="any" name="put_price"></label><br>
+    </div>
+    <div id="sell-fields">
+        <label>Stock Price: <input type="number" step="any" name="stock_price_sell"></label><br>
+        <label>Strike Price: <input type="number" step="any" name="strike_price"></label><br>
+        <label>Option Premium: <input type="number" step="any" name="option_premium"></label><br>
+    </div>
+    <button type="submit">Calculate</button>
+</form>
+{% if result %}
+    {% if result.error %}
+        <p class="error">{{ result.error }}</p>
+    {% elif result.type == 'move' %}
+        <p>Expected Move: {{ result.expected_move|round(2) }}</p>
+        <p>Expected Move %: {{ (result.expected_percentage*100)|round(2) }}%</p>
+        <p>Range: {{ result.lower_bound|round(2) }} - {{ result.upper_bound|round(2) }}</p>
+    {% else %}
+        <p>Profit from Selling: {{ result.profit_from_selling|round(2) }}</p>
+        <p>Profit from Exercising: {{ result.profit_from_exercising|round(2) }}</p>
+        <p>Extrinsic Value: {{ result.extrinsic_value|round(2) }}</p>
+    {% endif %}
+{% endif %}
+<script>
+// simple show/hide fields based on selection
+const select = document.querySelector('select[name="calc_type"]');
+const moveFields = document.getElementById('move-fields');
+const sellFields = document.getElementById('sell-fields');
+function toggle(){
+ if(select.value === 'move'){ moveFields.style.display='block'; sellFields.style.display='none'; }
+ else { moveFields.style.display='none'; sellFields.style.display='block'; }
+}
+select.addEventListener('change', toggle);
+toggle();
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- build Flask web app with separate pages for capital gains, DCA strategy, options strategy, and compound interest calculators
- implement reusable calculator logic modules
- add HTML templates and routing for interactive use

## Testing
- `git ls-files -z -- '*.py' | xargs -0 python -m py_compile`


------
https://chatgpt.com/codex/tasks/task_e_68a8c8520fdc8321883d3787152b0ceb